### PR TITLE
Add LDAPS capability to RT::Authen::ExternalAuth

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,6 +11,7 @@ readme_from;
 feature 'SSL LDAP Connections' =>
     -default => 0,
     recommends('Net::SSLeay' => 0),
+    recommends('Net::LDAPS' => 0),
     ;
 
 feature 'External LDAP Sources' => 

--- a/etc/RT_SiteConfig.pm
+++ b/etc/RT_SiteConfig.pm
@@ -98,6 +98,10 @@ Set($ExternalSettings,      {   # AN EXAMPLE DB SERVICE
                                                         # The server hosting the service
                                                         'server'                    =>  'server.domain.tld',
                                                         ## SERVICE-SPECIFIC SECTION
+                                                        #
+                                                        # If you need to use LDAPS (SSL rather than TLS),
+                                                        # set use_ldaps to 1;
+                                                        'use_ldaps'             => 0,
                                                         # If you can bind to your LDAP server anonymously you should 
                                                         # remove the user and pass config lines, otherwise specify them here:
                                                         # 

--- a/lib/RT/Authen/ExternalAuth/LDAP.pm
+++ b/lib/RT/Authen/ExternalAuth/LDAP.pm
@@ -3,6 +3,7 @@ package RT::Authen::ExternalAuth::LDAP;
 use Net::LDAP qw(LDAP_SUCCESS LDAP_PARTIAL_RESULTS);
 use Net::LDAP::Util qw(ldap_error_name);
 use Net::LDAP::Filter;
+use Net::LDAPS;
 
 use strict;
 
@@ -428,10 +429,18 @@ sub _GetBoundLdapObj {
     my $ldap_user       = $config->{'user'};
     my $ldap_pass       = $config->{'pass'};
     my $ldap_tls        = $config->{'tls'};
+    my $use_ldaps       = $config->{'use_ldaps'};
     my $ldap_ssl_ver    = $config->{'ssl_version'};
     my $ldap_args       = $config->{'net_ldap_args'};
     
-    my $ldap = new Net::LDAP($ldap_server, @$ldap_args);
+    my $ldap = 0;
+    if ($use_ldaps) {
+		$ldap = new Net::LDAPS($ldap_server, @$ldap_args);
+    }
+    else {
+		$ldap = new Net::LDAP($ldap_server, @$ldap_args);
+    }
+    
     
     unless ($ldap) {
         $RT::Logger->critical(  (caller(0))[3],


### PR DESCRIPTION
I've added the capability to use Net::LDAPS instead of vanilla Net::LDAP, and provided a single configuration option to switch back and forth, which is reflected in the example configuration.

I've also modified the Makefile to check for a working Net::LDAPS.

The pre-existing codebase only allows for the use of TLS. A full discussion of the difference can be found here:
http://search.cpan.org/~gbarr/perl-ldap-0.43/lib/Net/LDAP/Security.pod#How_does_an_LDAPS_connection_work
