### PR TITLE
Minor POD fixes

### DIFF
--- a/lib/RT/Authen/ExternalAuth.pm
+++ b/lib/RT/Authen/ExternalAuth.pm
@@ -11,7 +11,7 @@ RT::Authen::ExternalAuth - RT Authentication using External Sources
 This module provides the ability to authenticate RT users against one or
 more external data sources at once. It will also allow information about
 that user to be loaded from the same, or any other available, source as
-well as allowing multple redundant servers for each method.
+well as allowing multiple redundant servers for each method.
 
 The extension currently supports authentication and information from
 LDAP via the Net::LDAP module, and from any data source that an
@@ -75,7 +75,7 @@ plugin root.
 =head1 CONFIGURATION
 
 L<RT::Authen::ExternalAuth> provides a lot of flexibility with many
-configuration options.  The following desc these configuration options,
+configuration options.  The following describes these configuration options,
 and provides a complete example.
 
 =over 4
@@ -91,7 +91,7 @@ using C<My_LDAP>, remove C<My_MySQL> and C<My_SSO_Cookie>.
 
     Set($ExternalAuthPriority,  [ 'My_LDAP',
                                   'My_MySQL',
-                                  'My_SSO_Cookie'
+                                  'My_SSO_Cookie',
                                 ]
     );
 
@@ -105,7 +105,7 @@ disabled.
 
 Once a user record is found, no more services are checked.
 
-You CANNOT use a SSO cookie to retrieve information.
+You CANNOT use an SSO cookie to retrieve information.
 
 You should remove services you don't use, but you must define
 at least one service.
@@ -127,7 +127,7 @@ email to a support email address.
 
 These are the full settings for each external service as a hash of
 hashes.  Note that you may have as many external services as you wish.
-They will be checked in the order specified in L</$ExternalAuthPriority>
+They will be checked in the order specified in the L</$ExternalAuthPriority>
 and L</$ExternalInfoPriority> directives above.
 
 The outer structure is a key with the authentication option (name of
@@ -193,7 +193,7 @@ C<RealName> or building name).
 
 =item attr_map
 
-Mapping of RT attributes on to attributes in the external source.
+Mapping of RT attributes onto attributes in the external source.
 Valid keys are attributes of an
 L<RT::User|http://bestpractical.com/rt/docs/latest/RT/User.html>.
 The values are attributes from your authentication source.
@@ -220,7 +220,7 @@ For example, an LDAP mapping might look like:
 
     # Users created from LDAP should be Privileged; this is a core RT
     # option.  Additionally, this is the 4.2 name for the option; for RT
-    # 4.0, is it named $AutoCreate   See the core RT documentation at
+    # 4.0, is it named $AutoCreate.  See the core RT documentation at
     # http://docs.bestpractical.com/RT_Config#UserAutocreateDefaultsOnLogin
     # for for further details.
     Set( $UserAutocreateDefaultsOnLogin, { Privileged => 1 } );

--- a/lib/RT/Authen/ExternalAuth.pm
+++ b/lib/RT/Authen/ExternalAuth.pm
@@ -14,7 +14,7 @@ that user to be loaded from the same, or any other available, source as
 well as allowing multiple redundant servers for each method.
 
 The extension currently supports authentication and information from
-LDAP via the Net::LDAP module, and from any data source that an
+LDAP via the C<Net::LDAP> module, and from any data source that an
 installed DBI driver is available for.
 
 It is also possible to use cookies set by an alternate application for
@@ -68,7 +68,7 @@ You may not have all of these files.  It depends what versions you are
 upgrading between.
 
 If you are using a vendor packaged RT, your local directories are likely
-to be somewhere under /usr/local instead of in /opt/rt4 so you will need
+to be somewhere under C</usr/local> instead of in C</opt/rt4> so you will need
 to visit Configuration -> Tools -> System Configuration to find your
 plugin root.
 

--- a/lib/RT/Authen/ExternalAuth/DBI.pm
+++ b/lib/RT/Authen/ExternalAuth/DBI.pm
@@ -63,8 +63,8 @@ DBI-specific options are described here. Shared options
 are described in the F<etc/RT_SiteConfig.pm> file included
 in this distribution.
 
-The example in the L</SYNOPSIS> lists all available options
-and they are described below. See the L<DBI> module for details
+The example in the L</SYNOPSIS> lists all available options;
+they are also described below. See the L<DBI> module for details
 on debugging connection issues.
 
 =over 4
@@ -99,16 +99,16 @@ The database table containing the user information to check against.
 
 =item u_field
 
-The field in the table that holds usernames
+The field in the table that holds usernames.
 
 =item p_field
 
-The field in the table that holds passwords
+The field in the table that holds passwords.
 
 =item p_check
 
 Optional.  An anonymous subroutine definition used to check the (presumably
-hashed) passed from the database with the password entered by the user logging
+hashed) password from the database with the password entered by the user logging
 in.  The subroutine should return true on success and false on failure.  The
 configuration options C<p_enc_pkg> and C<p_enc_sub> will be ignored when
 C<p_check> is defined.

--- a/lib/RT/Authen/ExternalAuth/DBI.pm
+++ b/lib/RT/Authen/ExternalAuth/DBI.pm
@@ -135,7 +135,7 @@ load in your Perl installation.
 
 =item p_salt
 
-If p_enc_sub takes a salt as a second parameter then set it here.
+If C<p_enc_sub> takes a salt as a second parameter then set it here.
 
 =item d_field, d_values
 

--- a/lib/RT/Authen/ExternalAuth/DBI/Cookie.pm
+++ b/lib/RT/Authen/ExternalAuth/DBI/Cookie.pm
@@ -58,7 +58,7 @@ The username field in the users table.
 =item u_match_key
 
 The field in the users table that uniquely identifies a user
-and also exists in the cookies table. See c_match_key below.
+and also exists in the cookies table. See C<c_match_key> below.
 
 =item c_table
 
@@ -71,7 +71,7 @@ The field that stores cookie values.
 =item c_match_key
 
 The field in the cookies table that uniquely identifies a user
-and also exists in the users table. See u_match_key above.
+and also exists in the users table. See C<u_match_key> above.
 
 =item db_service_name
 

--- a/lib/RT/Authen/ExternalAuth/DBI/Cookie.pm
+++ b/lib/RT/Authen/ExternalAuth/DBI/Cookie.pm
@@ -39,7 +39,7 @@ are described in the F<etc/RT_SiteConfig.pm> file included
 in this distribution.
 
 The example in the L</SYNOPSIS> lists all available options
-and they are described below.
+as well as being described below.
 
 =over 4
 

--- a/lib/RT/Authen/ExternalAuth/LDAP.pm
+++ b/lib/RT/Authen/ExternalAuth/LDAP.pm
@@ -63,8 +63,8 @@ LDAP-specific options are described here. Shared options
 are described in the F<etc/RT_SiteConfig.pm> file included
 in this distribution.
 
-The example in the L</SYNOPSIS> lists all available options
-and they are described below. Note that many of these values
+The example in the L</SYNOPSIS> lists all available options;
+they are also described below. Note that many of these values
 are specific to LDAP, so you should consult your LDAP
 documentation for details.
 
@@ -79,7 +79,7 @@ The server hosting the LDAP or AD service.
 The username and password RT should use to connect to the LDAP
 server.
 
-If you can bind to your LDAP server anonymously you may be able to omit these
+If you can bind to your LDAP server anonymously, you may be able to omit these
 options.  Many servers do not allow anonymous binds, or restrict what information
 they can see or how much information they can retrieve.  If your server does not
 allow anonymous binds then you must have a service account created for this


### PR DESCRIPTION
These changes correct some typographical errors in the modules' POD and add some formatting to the text to highlight code or code-like elements.