### PR TITLE
Critical problems with auth db connections

### DIFF
--- a/lib/RT/Authen/ExternalAuth/DBI.pm
+++ b/lib/RT/Authen/ExternalAuth/DBI.pm
@@ -621,9 +621,23 @@ sub _GetBoundDBIObj {
             for sort keys %extra;
     }
 
+    my $db_type = RT->Config->Get('DatabaseType');
+    if ( $db_type eq 'Oracle' ) {
+        $ENV{'NLS_LANG'} = "AMERICAN_AMERICA.AL32UTF8";
+        $ENV{'NLS_NCHAR'} = "AL32UTF8";   
+    }
+
     # Now let's get connected
     my $dbh = DBI->connect($dsn, $db_user, $db_pass,{RaiseError => 1, AutoCommit => 0 })
             or die $DBI::errstr;
+
+    if ( $db_type eq 'mysql' ) {
+        $dbh->do("SET NAMES 'utf8'");                                
+    }
+
+    if ( $db_type eq 'Pg' ) {
+        $dbh->do("SET bytea_output = 'escape'");                    
+    }
 
     # If we didn't die, return the DBI object handle
     # and hope it's treated sensibly and correctly

--- a/lib/RT/Authen/ExternalAuth/DBI.pm
+++ b/lib/RT/Authen/ExternalAuth/DBI.pm
@@ -615,6 +615,12 @@ sub _GetBoundDBIObj {
         $dsn = "dbi:$dbi_driver:database=$db_database;host=$db_server;port=$db_port";
     }
 
+    if (RT->Config->Get('DatabaseExtraDSN')) {
+        my %extra = RT->Config->Get('DatabaseExtraDSN');
+        $dsn .= ";$_=$extra{$_}"
+            for sort keys %extra;
+    }
+
     # Now let's get connected
     my $dbh = DBI->connect($dsn, $db_user, $db_pass,{RaiseError => 1, AutoCommit => 0 })
             or die $DBI::errstr;


### PR DESCRIPTION
This pull request resolves two problems:

1. RT::Handle forces utf8 encoding on the RT database connection, so ExternalAuth::DBI MUST do the same since it does not perform on-the-fly character set conversion. Otherwise RT database may throw errors when non-utf8 characters are present in queries (e.g. accented characters in RealName field), or we may end up writing garbled text into RT tables.
2. New RT introduced DatabaseExtraDSN, but the module currently does not respect it.